### PR TITLE
Feat/auto hsv calibration

### DIFF
--- a/autonav_ws/src/autonav_display/src/display.py
+++ b/autonav_ws/src/autonav_display/src/display.py
@@ -6,7 +6,7 @@ from scr.states import DeviceStateEnum
 from scr_msgs.msg import SystemState, DeviceState, ConfigUpdated
 from scr_msgs.srv import SetSystemState, UpdateConfig, SetActivePreset, SaveActivePreset, GetPresets, DeletePreset
 from std_msgs.msg import Empty
-from autonav_msgs.msg import Position, MotorFeedback, MotorInput, MotorControllerDebug, PathingDebug, GPSFeedback, IMUData, Conbus
+from autonav_msgs.msg import Position, MotorFeedback, MotorInput, MotorControllerDebug, PathingDebug, GPSFeedback, IMUData, Conbus, CameraCalibration
 from sensor_msgs.msg import CompressedImage
 import asyncio
 import websockets
@@ -85,6 +85,7 @@ class BroadcastNode(Node):
         # Publishers
         self.conbus_p = self.create_publisher(Conbus, "/autonav/conbus/instruction", 100)
         self.broadcast_p = self.create_publisher(Empty, "/scr/state/broadcast", 20)
+        self.calibration_p = self.create_publisher(CameraCalibration, "/autonav/camera/calibration", 5)
 
         # Subscriptions
         self.device_state_s = self.create_subscription(DeviceState, "/scr/device_state", self.deviceStateCallback, 20)
@@ -227,6 +228,12 @@ class BroadcastNode(Node):
                 msg.data = data
                 msg.iterator = int(obj["iterator"]) if "iterator" in obj else 0
                 self.conbus_p.publish(msg)
+            
+            if obj["op"] == "calibrate":
+                msg = CameraCalibration()
+                # there's calibrate ramp, calibrate ground, and maybe a calibrate barrel and/or calibrate line and maybe a calibrate white balance or something (calibrat paper?)
+                msg.id = int(obj["id"]) # and I guess each will have it's own id or something                
+                self.calibration_p.publish(msg)
 
             if obj["op"] == "get_presets":
                 req = GetPresets.Request()

--- a/autonav_ws/src/autonav_display/src/display.py
+++ b/autonav_ws/src/autonav_display/src/display.py
@@ -232,7 +232,7 @@ class BroadcastNode(Node):
             if obj["op"] == "calibrate":
                 msg = CameraCalibration()
                 # there's calibrate ramp, calibrate ground, and maybe a calibrate barrel and/or calibrate line and maybe a calibrate white balance or something (calibrat paper?)
-                msg.id = int(obj["id"]) # and I guess each will have it's own id or something                
+                msg.include_in_mask = int(obj["include"]) # and I guess each will have it's own id or something                
                 self.calibration_p.publish(msg)
 
             if obj["op"] == "get_presets":

--- a/autonav_ws/src/autonav_msgs/CMakeLists.txt
+++ b/autonav_ws/src/autonav_msgs/CMakeLists.txt
@@ -27,6 +27,7 @@ set(msg_files
   "msg/SafetyLights.msg"
   "msg/Conbus.msg"
   "msg/PathingDebug.msg"
+  "msg/CameraCalibration.msg"
 )
 
 rosidl_generate_interfaces(${PROJECT_NAME}

--- a/autonav_ws/src/autonav_msgs/msg/CameraCalibration.msg
+++ b/autonav_ws/src/autonav_msgs/msg/CameraCalibration.msg
@@ -1,2 +1,2 @@
-#TODO include a list of which ids mean which thing
-int id
+# whether to include the colors in the mask or not
+bool include_in_mask

--- a/autonav_ws/src/autonav_msgs/msg/CameraCalibration.msg
+++ b/autonav_ws/src/autonav_msgs/msg/CameraCalibration.msg
@@ -1,0 +1,2 @@
+#TODO include a list of which ids mean which thing
+int id

--- a/autonav_ws/src/autonav_vision/src/transformations.py
+++ b/autonav_ws/src/autonav_vision/src/transformations.py
@@ -15,6 +15,7 @@ import json
 
 from scr.node import Node
 from scr.states import DeviceStateEnum
+from scr.utils import clamp
 
 g_bridge = CvBridge()
 
@@ -26,6 +27,21 @@ g_mapData.origin = Pose()
 g_mapData.origin.position.x = -10.0
 g_mapData.origin.position.y = -10.0
 
+# start in top left, go clockwise
+CALIBRATION_BOX = {
+    "right":[
+        (0, 215),
+        (80, 215),
+        (80, 290),
+        (0, 290)
+    ],
+    "left":[
+        (0, 215),
+        (400, 215),
+        (400, 290),
+        (0, 290)
+    ]
+}
 
 class ImageTransformerConfig:
     def __init__(self):
@@ -74,13 +90,13 @@ class ImageTransformer(Node):
         self.config = self.get_default_config()
         self.dir = dir
 
+        # 30 is a good +/- to use when dealing with OpenCV color values
+        self.pixelFactor = 30
+
     def directionify(self, topic):
         return topic + "/" + self.dir
 
     def init(self):
-        # don't break anything
-        self.system_state = OFF
-
         self.camera_subscriber = self.create_subscription(CompressedImage, self.directionify("/autonav/camera/compressed") , self.onImageReceived, self.qos_profile)
         self.calibration_subscriber = self.create_subscription(CameraCalibration, "/camera/autonav/calibration", self.onCalibrate)
         self.camera_debug_publisher = self.create_publisher(CompressedImage, self.directionify("/autonav/camera/compressed") + "/cutout", self.qos_profile)
@@ -89,33 +105,47 @@ class ImageTransformer(Node):
 
         self.set_device_state(DeviceStateEnum.OPERATING)
     
-    def system_state_transition(self, old: SystemState, updated: SystemState):
-        self.system_state = updated
-
     def onCalibrate(self, msg: CameraCalibration):
         # only allow calibration if it's safe to do so, don't want to accidentally ruin a run or kill a person
-        if self.system_state.state is not AUTONOMOUS and self.system_state.mobility is False:
+        if self.system_state is not SystemStateEnum.AUTONOMOUS and not self.mobility:
             # remember that the mask is reversed though, we filter OUT the ground
             # so ground needs to be in the threshold range, but not obstacles
-            # include in the mask, so it gets filtered out
-            if msg.include_in_mask:
-                pixels = [] #TODO
-                avgHue, avgSat, avgVal = getAverageVal(pixels) #TODO
+            pts = CALIBRATION_BOX[self.dir]
 
-                # take the lower of the current and calibrated values, so that as much as possible is included in the mask
-                self.config.lower_hue = min(self.config.lower_hue, avgHue)
-                self.config.lower_sat = min(self.config.lower_sat, avgSat)
-                self.config.lower_val = min(self.config.lower_val, avgVal)
+            avgH = avgV = avgS = 0
+            # for every pixel in the calibration box square thing
+            for pixel in self.image[pts[0][0]:pts[1][0], pts[0][1]:pts[3][1]]:
+                avgH += pixel[0]
+                avgS += pixel[1]
+                avgV +=pixel[2]
+            
+            # then calculate number of pixles and divide out to get the average values
+            numPixels = abs((pts[0][0] - pts[1][0]) * (pts[0][1] - pts[3][1]))
+            avgH /= numPixels
+            avgS /= numPixels
+            avgV /= numPixels
 
-                # take the upper of the current and calibrated values, so that as much as possible is included in the mask
-                self.config.upper_hue = max(self.config.upper_hue, avgHue)
-                self.config.upper_sat = max(self.config.upper_sat, avgSat)
-                self.config.upper_val = max(self.config.upper_val, avgVal)
-                
-            # exclude from the mask, so it shows up for expandification
-            else:
-                pass #TODO
+            # take the lower of the current and calibrated values, so that as much as possible is included in the mask if we are including in the mask,
+            # else we take the upper of the two to shrink the range of values we filter
+            # then we have a fudge factor to not overfit or whatever
+            self.config.lower_hue = min(self.config.lower_hue, avgHue - self.pixelFactor) if msg.include_in_mask else max(self.config.lower_hue, avgHue + self.pixelFactor)
+            self.config.lower_sat = min(self.config.lower_sat, avgSat - self.pixelFactor) if msg.include_in_mask else max(self.config.lower_sat, avgSat + self.pixelFactor)
+            self.config.lower_val = min(self.config.lower_val, avgVal - self.pixelFactor) if msg.include_in_mask else max(self.config.lower_val, avgVal + self.pixelFactor)
 
+            # take the upper of the current and calibrated values, so that as much as possible is included in the mask
+            # else we take the lower of the two values to shrink the range down
+            self.config.upper_hue = max(self.config.upper_hue, avgHue + self.pixelFactor) if msg.include_in_mask else min(self.config.lower_hue, avgHue - self.pixelFactor)
+            self.config.upper_sat = max(self.config.upper_sat, avgSat + self.pixelFactor) if msg.include_in_mask else min(self.config.lower_sat, avgSat - self.pixelFactor)
+            self.config.upper_val = max(self.config.upper_val, avgVal + self.pixelFactor) if msg.include_in_mask else min(self.config.lower_val, avgVal - self.pixelFactor)
+
+            # and we just did some shenanigans with the values and pixelFactor and everything so clamp everything to be safe
+            self.config.lower_hue = clamp(self.config.lower_hue, 0, 255)
+            self.config.lower_sat = clamp(self.config.lower_sat, 0, 255)
+            self.config.lower_val = clamp(self.config.lower_val, 0, 255)
+            self.config.upper_hue = clamp(self.config.upper_hue, 0, 255)
+            self.config.upper_sat = clamp(self.config.upper_sat, 0, 255)
+            self.config.upper_val = clamp(self.config.upper_val, 0, 255)
+    
     def config_updated(self, jsonObject):
         self.config = json.loads(self.jdump(jsonObject), object_hook=lambda d: SimpleNamespace(**d))
 
@@ -246,7 +276,7 @@ class ImageTransformer(Node):
         cv2.polylines(img_copy, [np.array(pts)], True, (0, 0, 255), 2)
 
         # Draw calibration square points
-        pts = [] #TODO
+        pts = CALIBRATION_BOX[self.dir]
         cv2.polylines(img_copy, [np.array(pts)], True, (255, 0, 0), 2)
 
         self.camera_debug_publisher.publish(g_bridge.cv2_to_compressed_imgmsg(img_copy))

--- a/display/index.html
+++ b/display/index.html
@@ -108,6 +108,10 @@
                 <div class="divider">
                     <h3>Vision</h3>
                 </div>
+                <div class="controls-row">
+                    <button type="button" class="btn btn-outline-primary" id="calibrate_include">Calibrate Ground</button>
+                    <button type="button" class="btn btn-outline-primary" id="calibrate_exclude">Calibrate Obstacle</button>
+                </div>
                 <div class="section" id="images">
                     <div class="roww">
                         <img width="480" height="640" id="target_raw_camera_left" data-type="regular">

--- a/display/scripts/globals.js
+++ b/display/scripts/globals.js
@@ -16,7 +16,7 @@ var deviceStates = {};
 var logs = [];
 var iterator = 0;
 var iterators = [];
-var development_mode = false;
+var development_mode = true;
 var current_preset = "ERROR_NO_PRESET_AUTODETECTED";
 
 var addressKeys = {

--- a/display/scripts/main.js
+++ b/display/scripts/main.js
@@ -558,14 +558,14 @@ $(document).ready(function () {
     $("#calibrate_include").on("click", function () {
         send({
             op: "calibrate",
-            id: 0
+            include: true
         });
     });
 
     $("#calibrate_exclude").on("click", function () {
         send({
             op: "calibrate",
-            id: 1
+            include: false
         });
     });
 

--- a/display/scripts/main.js
+++ b/display/scripts/main.js
@@ -555,6 +555,20 @@ $(document).ready(function () {
         }
     });
 
+    $("#calibrate_include").on("click", function () {
+        send({
+            op: "calibrate",
+            id: 0
+        });
+    });
+
+    $("#calibrate_exclude").on("click", function () {
+        send({
+            op: "calibrate",
+            id: 1
+        });
+    });
+
     $("#save_preset_mode").on("click", function () {
         send({
             op: "save_preset_mode"


### PR DESCRIPTION
not fully automatic, but basically you line the box on the UI up with something (e.g. a white piece of paper, the ramp, the ground, etc) and click either "include" or "exclude" from the mask on the UI, and it does some automatic stuff to adjust the HSV threshold values as necessary. this would replace the whole guess/check method and also make it so we don't need Noah running around with a webcam and a color picker program on a laptop.